### PR TITLE
Calibration rig

### DIFF
--- a/calibration_utils.py
+++ b/calibration_utils.py
@@ -89,7 +89,8 @@ def polygon_from_image_name(image_name):
 class StereoCalibration(object):
     """Class to Calculate Calibration and Rectify a Stereo Camera."""
 
-    def __init__(self, traceLevel: float = 1.0, outputScaleFactor: float = 0.5, disableCamera: list = []):
+    def __init__(self, traceLevel: float = 1.0, outputScaleFactor: float = 0.5, disableCamera: list = [], model = None):
+        self.model = model
         self.traceLevel = traceLevel
         self.output_scale_factor = outputScaleFactor
         self.disableCamera = disableCamera
@@ -533,8 +534,22 @@ class StereoCalibration(object):
             for i in range(len(filtered_ids)):
                 obj_points.append(self.charuco_ids_to_objpoints(filtered_ids[i]))
 
-        flags = (cv2.CALIB_USE_INTRINSIC_GUESS + 
-                 cv2.CALIB_RATIONAL_MODEL + cv2.CALIB_TILTED_MODEL)
+        if self.model == None:
+            flags = (cv2.CALIB_USE_INTRINSIC_GUESS + 
+                 cv2.CALIB_RATIONAL_MODEL)
+        elif isinstance(self.model, str):
+            if self.model == "NORMAL":
+                flags = (cv2.CALIB_USE_INTRINSIC_GUESS + 
+                    cv2.CALIB_RATIONAL_MODEL)
+            if self.model == "TILTED":
+                flags = (cv2.CALIB_USE_INTRINSIC_GUESS + 
+                    cv2.CALIB_RATIONAL_MODEL + cv2.CALIB_TILTED_MODEL)
+
+            elif self.model == "PRISM":
+                flags = (cv2.CALIB_USE_INTRINSIC_GUESS + 
+                    cv2.CALIB_RATIONAL_MODEL + cv2.CALIB_TILTED_MODEL)
+        elif "cv2" in str(type(self.model)):
+            flags = self.model
 
     #     flags = (cv2.CALIB_RATIONAL_MODEL)
         (ret, camera_matrix, distortion_coefficients,
@@ -679,10 +694,22 @@ class StereoCalibration(object):
             # flags |= cv2.CALIB_USE_EXTRINSIC_GUESS
             # print(flags)
 
-            flags |= cv2.CALIB_FIX_INTRINSIC
-            # flags |= cv2.CALIB_USE_INTRINSIC_GUESS
-            flags |= cv2.CALIB_RATIONAL_MODEL
-            flags |= cv2.CALIB_TILTED_MODEL
+            if self.model == None:
+                flags = (cv2.CALIB_FIX_INTRINSIC + 
+                    cv2.CALIB_RATIONAL_MODEL)
+            elif isinstance(self.model, str):
+                if self.model == "NORMAL":
+                    flags = (cv2.CALIB_FIX_INTRINSIC + 
+                        cv2.CALIB_RATIONAL_MODEL)
+                if self.model == "TILTED":
+                    flags = (cv2.CALIB_FIX_INTRINSIC + 
+                        cv2.CALIB_RATIONAL_MODEL + cv2.CALIB_TILTED_MODEL)
+
+                elif self.model == "PRISM":
+                    flags = (cv2.CALIB_FIX_INTRINSIC + 
+                        cv2.CALIB_RATIONAL_MODEL + cv2.CALIB_TILTED_MODEL)
+            elif "cv2" in str(type(self.model)):
+                flags = self.model
             # print(flags)
             if self.traceLevel == 3 or self.traceLevel == 10:
                 print('Printing Extrinsics guesses...')

--- a/calibration_utils.py
+++ b/calibration_utils.py
@@ -1060,10 +1060,6 @@ class StereoCalibration(object):
         try:
             whole = time.time()
             while True:
-                for i in range(len(distortion_coefficients)):
-                    if i not in distortion_array.keys():
-                        distortion_array[i] = []
-                    distortion_array[i].append(distortion_coefficients[i][0])
                 intrinsic_array['f_x'].append(camera_matrix[0][0])
                 intrinsic_array['f_y'].append(camera_matrix[1][1])
                 intrinsic_array['c_x'].append(camera_matrix[0][2])
@@ -1080,6 +1076,10 @@ class StereoCalibration(object):
                 num_corners.append(len(removed_corners))
                 iterations_array.append(index)
                 reprojection.append(ret)
+                for i in range(len(distortion_coefficients)):
+                    if i not in distortion_array.keys():
+                        distortion_array[i] = []
+                    distortion_array[i].append(distortion_coefficients[i][0])
                 print(f"Each filtering {time.time() - start}")
                 if self.traceLevel == 8:
                     _, bins, _ = ax.hist(all_error, range = [0,30], bins = 100, label = f"Iteration {index}, number filtered: {len(removed_corners)}", color= plt.cm.summer(1-(index-1)/10), alpha = 0.3, edgecolor ="black")  

--- a/calibration_utils.py
+++ b/calibration_utils.py
@@ -195,7 +195,7 @@ class StereoCalibration(object):
                 image_files.sort()
                 for im in image_files:
                     frame = cv2.imread(im)
-                    self.height, self.width, _ = 1280, 800, 0
+                    self.height, self.width, _ = frame.shape
                     widthRatio = resizeWidth / self.width
                     heightRatio = resizeHeight / self.height
                     if (widthRatio > 0.8 and heightRatio > 0.8 and widthRatio <= 1.0 and heightRatio <= 1.0) or (widthRatio > 1.2 and heightRatio > 1.2) or (resizeHeight == 0):
@@ -430,8 +430,7 @@ class StereoCalibration(object):
 
         # Here we need to get initialK and parameters for each camera ready and fill them inside reconstructed reprojection error per point
         ret = 0.0
-        threshold = 10.0
-
+        threshold = 50.0
         filtered_corners, filtered_ids,all_error, removed_corners, removed_ids, removed_error = self.features_filtering_function(rvecs, tvecs, cameraMatrixInit, distCoeffsInit, ret, allCorners, allIds, camera = name, threshold = threshold)
         return removed_corners, filtered_corners, filtered_ids
     
@@ -618,7 +617,9 @@ class StereoCalibration(object):
                 plt.grid()
                 plt.show()
 
-            if self.traceLevel == 5 or self.traceLevel == 10:
+            if self.traceLevel == 9 or self.traceLevel == 10:
+                if len(removed_corners) < 2:
+                    continue
                 centroid_x = np.mean(np.array(removed_corners).T[0])
                 centroid_y = np.mean(np.array(removed_corners).T[1])
 
@@ -728,7 +729,6 @@ class StereoCalibration(object):
                         green = 0 
                     else:
                         count = round(count, 4)
-                        threshold = 1
                         red = int(((count / threshold)) * 255)
                         green = int((1 -count / threshold) * 255)
                     color = (0, green, red)
@@ -1030,12 +1030,10 @@ class StereoCalibration(object):
 
         # Here we need to get initialK and parameters for each camera ready and fill them inside reconstructed reprojection error per point
         ret = 0.0
-        threshold = 10.0
         flags = cv2.CALIB_USE_INTRINSIC_GUESS
         flags += distortion_flags
 
         #     flags = (cv2.CALIB_RATIONAL_MODEL)
-        threshold = 20
         reprojection = []
         removed_errors = []
         num_corners = []
@@ -1055,7 +1053,7 @@ class StereoCalibration(object):
         translation_array_z = []
         corner_checker = 0
         previous_ids = []
-        threshold = 3
+        threshold = 10
         import time
         try:
             whole = time.time()
@@ -1122,9 +1120,9 @@ class StereoCalibration(object):
                         plt.grid()
                         plt.show()
                         plt.title(f"Distortion after {int(index) + 1} iterations, threshold {threshold}")
-                        for key, distortion in distortion_array.items():
+                        """for key, distortion in distortion_array.items():
                             if distortion[0] != 0:
-                                plt.plot(iterations_array,distortion, label = f"Distortion: {key}")
+                                plt.plot(iterations_array,distortion, label = f"Distortion: {key}")"""
                         plt.ylabel("Absolute change")
                         plt.grid()
                         plt.legend()

--- a/calibration_utils.py
+++ b/calibration_utils.py
@@ -78,7 +78,7 @@ def select_polygon_coords(p_coordinates, indexes):
 
 
 def image_filename(polygon_index, total_num_of_captured_images):
-    return "p{polygon_index}_{total_num_of_captured_images}.png".format(stream_name=stream_name, polygon_index=polygon_index, total_num_of_captured_images=total_num_of_captured_images)
+    return "p{polygon_index}_{total_num_of_captured_images}.png".format(polygon_index=polygon_index, total_num_of_captured_images=total_num_of_captured_images)
 
 
 def polygon_from_image_name(image_name):

--- a/calibration_utils.py
+++ b/calibration_utils.py
@@ -89,6 +89,7 @@ class StereoCalibration(object):
     """Class to Calculate Calibration and Rectify a Stereo Camera."""
 
     def __init__(self):
+        self.traceLevel = 0
         """Class to Calculate Calibration and Rectify a Stereo Camera."""
 
     def calibrate(self, board_config, filepath, square_size, mrk_size, squaresX, squaresY, camera_model, enable_disp_rectify):

--- a/calibration_utils.py
+++ b/calibration_utils.py
@@ -622,11 +622,11 @@ class StereoCalibration(object):
                             print(f"tried maximum crop factor and still no success")
                             break
             if success:
-                # trying the full FOV once more with better initial parameters
+                # trying the full FOV once more with better initial K
                 print(f"new K init {K}")
                 print(f"new d_init {d}")
                 try:
-                    return cv2.fisheye.calibrate(obj_points, allCorners, imsize, K, d, flags=flags, criteria=term_criteria)
+                    return cv2.fisheye.calibrate(obj_points, allCorners, imsize, K, distCoeffsInit, flags=flags, criteria=term_criteria)
                 except:
                     print(f"Failed the full res calib, returning calibration with crop factor {crop}")
                     return res, K, d, rvecs, tvecs

--- a/calibration_utils.py
+++ b/calibration_utils.py
@@ -534,7 +534,7 @@ class StereoCalibration(object):
                 obj_points.append(self.charuco_ids_to_objpoints(filtered_ids[i]))
 
         flags = (cv2.CALIB_USE_INTRINSIC_GUESS + 
-                 cv2.CALIB_RATIONAL_MODEL)
+                 cv2.CALIB_RATIONAL_MODEL + cv2.CALIB_TILTED_MODEL)
 
     #     flags = (cv2.CALIB_RATIONAL_MODEL)
         (ret, camera_matrix, distortion_coefficients,
@@ -682,6 +682,7 @@ class StereoCalibration(object):
             flags |= cv2.CALIB_FIX_INTRINSIC
             # flags |= cv2.CALIB_USE_INTRINSIC_GUESS
             flags |= cv2.CALIB_RATIONAL_MODEL
+            flags |= cv2.CALIB_TILTED_MODEL
             # print(flags)
             if self.traceLevel == 3 or self.traceLevel == 10:
                 print('Printing Extrinsics guesses...')

--- a/calibration_utils.py
+++ b/calibration_utils.py
@@ -172,9 +172,10 @@ class StereoCalibration(object):
             cv2.imwrite(coverage_file_path, subImage)
 
         combinedCoverageImage = cv2.resize(combinedCoverageImage, (0, 0), fx=self.output_scale_factor, fy=self.output_scale_factor)
-        cv2.imshow('coverage image', combinedCoverageImage)
-        cv2.waitKey(0)
-        cv2.destroyAllWindows()
+        if enable_disp_rectify:
+            cv2.imshow('coverage image', combinedCoverageImage)
+            cv2.waitKey(0)
+            cv2.destroyAllWindows()
         
         for camera in board_config['cameras'].keys():
             left_cam_info = board_config['cameras'][camera]

--- a/calibration_utils.py
+++ b/calibration_utils.py
@@ -90,6 +90,7 @@ class StereoCalibration(object):
 
     def __init__(self):
         self.traceLevel = 0
+        self.output_scale_factor = 1.0
         """Class to Calculate Calibration and Rectify a Stereo Camera."""
 
     def calibrate(self, board_config, filepath, square_size, mrk_size, squaresX, squaresY, camera_model, enable_disp_rectify):

--- a/calibration_utils.py
+++ b/calibration_utils.py
@@ -609,18 +609,18 @@ class StereoCalibration(object):
                             corners_tmp.append(corner)
                     obj_points_limited.append(np.array(obj_points_tmp))
                     corners_limited.append(np.array(corners_tmp))
-                    try:
-                        res, K, d, rvecs, tvecs = cv2.fisheye.calibrate(obj_points_limited, corners_limited, imsize, cameraMatrixInit, distCoeffsInit, flags=flags, criteria=term_criteria)
-                        print(f"success with crop factor {crop}")
-                        success = True
+                try:
+                    res, K, d, rvecs, tvecs = cv2.fisheye.calibrate(obj_points_limited, corners_limited, imsize, cameraMatrixInit, distCoeffsInit, flags=flags, criteria=term_criteria)
+                    print(f"success with crop factor {crop}")
+                    success = True
+                    break
+                except:
+                    print(f"failed with crop factor {crop}")
+                    if crop > 0.7:
+                        crop -= 0.05
+                    else:
+                        print(f"tried maximum crop factor and still no success")
                         break
-                    except:
-                        print(f"failed with crop factor {crop}")
-                        if crop > 0.7:
-                            crop -= 0.05
-                        else:
-                            print(f"tried maximum crop factor and still no success")
-                            break
             if success:
                 # trying the full FOV once more with better initial K
                 print(f"new K init {K}")

--- a/calibration_utils.py
+++ b/calibration_utils.py
@@ -167,7 +167,7 @@ class StereoCalibration(object):
             else:
                 combinedCoverageImage = np.hstack((combinedCoverageImage, subImage))
             coverage_file_path = filepath + '/' + coverage_name + '_coverage.png'
-            cv2.imwrite(coverage_file_path, coverageImage)
+            cv2.imwrite(coverage_file_path, subImage)
 
         combinedCoverageImage = cv2.resize(combinedCoverageImage, (0, 0), fx=self.output_scale_factor, fy=self.output_scale_factor)
         cv2.imshow('coverage image', combinedCoverageImage)

--- a/calibration_utils.py
+++ b/calibration_utils.py
@@ -558,24 +558,7 @@ class StereoCalibration(object):
         if self.traceLevel == 3 or self.traceLevel == 10:
             print('Per View Errors...')
             print(perViewErrors)
-        # check if there are any suspicious corners with high reprojection error
-        corners_removed, filtered_ids, filtered_corners = self.filter_corner_outliers(allIds, allCorners, camera_matrix, distortion_coefficients, rotation_vectors, translation_vectors)
-        
-        if corners_removed:
-            # recompute the calibration if we removed any offending points
-            print("recomputing intrinsics")
-            (ret, camera_matrix, distortion_coefficients,
-                rotation_vectors, translation_vectors,
-                stdDeviationsIntrinsics, stdDeviationsExtrinsics,
-                perViewErrors) = cv2.aruco.calibrateCameraCharucoExtended(
-                    charucoCorners=filtered_corners,
-                    charucoIds=filtered_ids,
-                    board=self.board,
-                    imageSize=imsize,
-                    cameraMatrix=cameraMatrixInit,
-                    distCoeffs=distCoeffsInit,
-                    flags=flags,
-                    criteria=(cv2.TERM_CRITERIA_EPS & cv2.TERM_CRITERIA_COUNT, 50000, 1e-9))
+
         return ret, camera_matrix, distortion_coefficients, rotation_vectors, translation_vectors, filtered_ids, filtered_corners
 
     def calibrate_fisheye(self, allCorners, allIds, imsize, hfov):
@@ -663,16 +646,6 @@ class StereoCalibration(object):
                 except:
                     print(f"Failed the full res calib, using calibration with crop factor {crop}")
         
-        # check if there are any suspicious corners with high reprojection error after calib
-        corners_removed, filtered_ids, filtered_corners = self.filter_corner_outliers(allIds, filtered_corners, K, d, rvecs, tvecs)
-        if corners_removed:
-            # recompute the calibration if we removed any offending points
-            obj_points = []
-            for i in range(len(filtered_ids)):
-                obj_points.append(self.charuco_ids_to_objpoints(filtered_ids[i]))
-            print("recomputing intrinsics")
-            res, K, d, rvecs, tvecs =  cv2.fisheye.calibrate(obj_points, filtered_corners, None, K, d, flags=flags, criteria=term_criteria) 
-            print(f"Updated intrinsics: {K}")
         return res, K, d, rvecs, tvecs, filtered_ids, filtered_corners
 
 

--- a/calibration_utils.py
+++ b/calibration_utils.py
@@ -553,6 +553,12 @@ class StereoCalibration(object):
                 flags += cv2.CALIB_RATIONAL_MODEL
                 flags += cv2.CALIB_TILTED_MODEL
                 flags += cv2.CALIB_THIN_PRISM_MODEL
+            elif self.model == "THERMAL":
+                print("Using THERMAL model")
+                flags += cv2.CALIB_RATIONAL_MODEL
+                flags += cv2.CALIB_FIX_K3
+                flags += cv2.CALIB_FIX_K5
+                flags += cv2.CALIB_FIX_K6
 
         elif isinstance(self.model, int):
             print("Using CUSTOM flags")
@@ -714,6 +720,12 @@ class StereoCalibration(object):
                     flags += cv2.CALIB_RATIONAL_MODEL 
                     flags += cv2.CALIB_TILTED_MODEL
                     flags += cv2.CALIB_THIN_PRISM_MODEL
+                elif self.model == "THERMAL":
+                    print("Using THERMAL model")
+                    flags += cv2.CALIB_RATIONAL_MODEL
+                    flags += cv2.CALIB_FIX_K3
+                    flags += cv2.CALIB_FIX_K5
+                    flags += cv2.CALIB_FIX_K6
 
             elif isinstance(self.model, int):
                 flags = self.model

--- a/calibration_utils.py
+++ b/calibration_utils.py
@@ -804,8 +804,8 @@ class StereoCalibration(object):
             imgpoints2 = objpoints.copy()
 
             all_corners = corners.copy()
-            all_corners = np.array([all_corners[id[0]-1] for id in objects])
-            imgpoints2 = np.array([imgpoints2[id[0]-1] for id in objects])
+            all_corners = np.array([all_corners[id[0]] for id in objects])
+            imgpoints2 = np.array([imgpoints2[id[0]] for id in objects])
 
             ret, rvec, tvec = cv2.solvePnP(imgpoints2, all_corners, K, d)
             imgpoints2, _ = cv2.projectPoints(imgpoints2, rvec, tvec, self.cameraIntrinsics[self.name], self.cameraDistortion[self.name])

--- a/calibration_utils.py
+++ b/calibration_utils.py
@@ -541,7 +541,7 @@ class StereoCalibration(object):
             if self.model == "NORMAL":
                 flags = (cv2.CALIB_USE_INTRINSIC_GUESS + 
                     cv2.CALIB_RATIONAL_MODEL)
-            if self.model == "TILTED":
+            elif self.model == "TILTED":
                 flags = (cv2.CALIB_USE_INTRINSIC_GUESS + 
                     cv2.CALIB_RATIONAL_MODEL + cv2.CALIB_TILTED_MODEL)
 

--- a/calibration_utils.py
+++ b/calibration_utils.py
@@ -186,6 +186,8 @@ class StereoCalibration(object):
         # parameters = aruco.DetectorParameters_create()
         combinedCoverageImage = None
         resizeWidth, resizeHeight = 1280, 800
+        self.height = {}
+        self.width = {}
         assert mrk_size != None,  "ERROR: marker size not set"
         for camera in board_config['cameras'].keys():
             cam_info = board_config['cameras'][camera]
@@ -195,12 +197,12 @@ class StereoCalibration(object):
                 image_files.sort()
                 for im in image_files:
                     frame = cv2.imread(im)
-                    self.height, self.width, _ = frame.shape
-                    widthRatio = resizeWidth / self.width
-                    heightRatio = resizeHeight / self.height
+                    self.height[cam_info["name"]], self.width[cam_info["name"]], _ = frame.shape
+                    widthRatio = resizeWidth / self.width[cam_info["name"]]
+                    heightRatio = resizeHeight / self.height[cam_info["name"]]
                     if (widthRatio > 0.8 and heightRatio > 0.8 and widthRatio <= 1.0 and heightRatio <= 1.0) or (widthRatio > 1.2 and heightRatio > 1.2) or (resizeHeight == 0):
-                        resizeWidth = self.width
-                        resizeHeight = self.height
+                        resizeWidth = self.width[cam_info["name"]]
+                        resizeHeight = self.height[cam_info["name"]]
                     break
         for camera in board_config['cameras'].keys():
             cam_info = board_config['cameras'][camera]
@@ -375,18 +377,18 @@ class StereoCalibration(object):
                                 print(f"Epipolar error {extrinsics[0]}")
                                 left_cam_info['extrinsics']['epipolar_error'] = extrinsics[0]
                                 left_cam_info['extrinsics']['stereo_error'] = extrinsics[0]
-                            #self.test_epipolar_charuco(left_cam_info['name'], 
-                            #                            right_cam_info['name'],
-                            #                            left_path, 
-                            #                            right_path, 
-                            #                            left_cam_info['intrinsics'], 
-                            #                            left_cam_info['dist_coeff'], 
-                            #                            right_cam_info['intrinsics'], 
-                            #                            right_cam_info['dist_coeff'], 
-                            #                            extrinsics[2], # Translation between left and right Cameras
-                            #                            extrinsics[3], # Left Rectification rotation 
-                            #                            extrinsics[4]) # Right Rectification rotation 
-                            #                                                                
+                            """self.test_epipolar_charuco(left_cam_info['name'], 
+                                                        right_cam_info['name'],
+                                                        left_path, 
+                                                        right_path, 
+                                                        left_cam_info['intrinsics'], 
+                                                        left_cam_info['dist_coeff'], 
+                                                        right_cam_info['intrinsics'], 
+                                                        right_cam_info['dist_coeff'], 
+                                                        extrinsics[2], # Translation between left and right Cameras
+                                                        extrinsics[3], # Left Rectification rotation 
+                                                        extrinsics[4]) # Right Rectification rotation """
+                                                                                            
     
                             left_cam_info['extrinsics']['rotation_matrix'] = extrinsics[1]
                             left_cam_info['extrinsics']['translation'] = extrinsics[2]
@@ -401,7 +403,7 @@ class StereoCalibration(object):
                 ids, charucos = charuco_img
                 allCorners.append(charucos)
                 allIds.append(ids)
-            imsize = (self.height, self.width)
+            imsize = (self.height[name], self.width[name])
             return allCorners, allIds, imsize
 
         elif features == None or features == "charucos":
@@ -430,8 +432,23 @@ class StereoCalibration(object):
 
         # Here we need to get initialK and parameters for each camera ready and fill them inside reconstructed reprojection error per point
         ret = 0.0
-        threshold = 50.0
-        filtered_corners, filtered_ids,all_error, removed_corners, removed_ids, removed_error = self.features_filtering_function(rvecs, tvecs, cameraMatrixInit, distCoeffsInit, ret, allCorners, allIds, camera = name, threshold = threshold)
+        distortion_flags = self.get_distortion_flags(name)
+        flags = cv2.CALIB_USE_INTRINSIC_GUESS + distortion_flags
+        filtered_corners, filtered_ids,all_error, removed_corners, removed_ids, removed_error = self.features_filtering_function(rvecs, tvecs, cameraMatrixInit, distCoeffsInit, ret, allCorners, allIds, camera = name)
+        (ret, camera_matrix, distortion_coefficients,
+                 rotation_vectors, translation_vectors,
+                 stdDeviationsIntrinsics, stdDeviationsExtrinsics,
+                 perViewErrors) = cv2.aruco.calibrateCameraCharucoExtended(
+                    charucoCorners=filtered_corners,
+                    charucoIds=filtered_ids,
+                    board=self.board,
+                    imageSize=imsize,
+                    cameraMatrix=cameraMatrixInit,
+                    distCoeffs=distCoeffsInit,
+                    flags=flags,
+                    criteria=(cv2.TERM_CRITERIA_EPS & cv2.TERM_CRITERIA_COUNT, 50000, 1e-9))
+        self.cameraIntrinsics[name] = camera_matrix
+        self.cameraDistortion[name] = distortion_coefficients
         return removed_corners, filtered_corners, filtered_ids
     
     def remove_features(self, allCorners, allIds, array, img_files = None):
@@ -493,10 +510,6 @@ class StereoCalibration(object):
                 distortion_flags = self.get_distortion_flags(name)
                 ret, camera_matrix, distortion_coefficients, rotation_vectors, translation_vectors, filtered_ids, filtered_corners, allCorners, allIds  = self.calibrate_camera_charuco(
                     all_Features, all_features_Ids,allCorners, allIds, imsize, hfov, name, distortion_flags)
-                if self.filtering_enable or self.traceLevel != 0:
-                    filtered_corners, filtered_ids,all_error, removed_corners, removed_ids, removed_error = self.features_filtering_function(rotation_vectors, translation_vectors, camera_matrix, distortion_coefficients, ret, filtered_corners, filtered_ids, camera = name)
-                    ret, camera_matrix, distortion_coefficients, rotation_vectors, translation_vectors, filtered_ids, filtered_corners, allCorners, allIds  = self.calibrate_camera_charuco(
-                        all_Features, all_features_Ids, filtered_corners, filtered_ids, imsize, hfov, name, distortion_flags)
             if self.charucos == {}:
                 self.undistort_visualization(
                     image_files, camera_matrix, distortion_coefficients, imsize, name)
@@ -534,7 +547,8 @@ class StereoCalibration(object):
         # Draw the line on the image
         cv2.line(displayframe, start_point, end_point, color, thickness)
         return displayframe
-    def features_filtering_function(self,rvecs, tvecs, cameraMatrix, distCoeffs, reprojection, filtered_corners,filtered_id, camera, display = True, threshold = 1.0, draw_quadrants = False, nx = 4, ny = 4):
+
+    def features_filtering_function(self,rvecs, tvecs, cameraMatrix, distCoeffs, reprojection, filtered_corners,filtered_id, camera, display = True, threshold = None, draw_quadrants = False, nx = 4, ny = 4):
         whole_error = []
         all_points = []
         all_corners = []
@@ -558,6 +572,8 @@ class StereoCalibration(object):
                 imgpoints2 = imgpoints2.reshape(-1, 2)
 
                 errors = np.linalg.norm(corners2 - imgpoints2, axis=1)
+                if threshold == None:
+                    threshold = max(2*np.median(errors), 100)
                 valid_mask = errors <= threshold
                 removed_mask = ~valid_mask
 
@@ -589,7 +605,7 @@ class StereoCalibration(object):
             total_error_squared = 0
             total_points = 0
 
-            if self.traceLevel == 5 or self.traceLevel == 10:
+            if self.traceLevel == 7 or self.traceLevel == 10:
                 centroid_x = np.mean(np.array(display_corners).T[0])
                 centroid_y = np.mean(np.array(display_corners).T[1])
 
@@ -610,16 +626,14 @@ class StereoCalibration(object):
                 cbar = plt.colorbar(img, ax=ax)
                 cbar.set_label("Reprojection error")
                 ax.set_xlabel('Width')
-                ax.set_xlim([0,self.width])
-                ax.set_ylim([0,self.height])
+                ax.set_xlim([0,self.width[camera]])
+                ax.set_ylim([0,self.height[camera]])
                 ax.legend()
                 ax.set_ylabel('Y coordinate')
                 plt.grid()
                 plt.show()
 
-            if self.traceLevel == 9 or self.traceLevel == 10:
-                if len(removed_corners) < 2:
-                    continue
+            if self.traceLevel == 8 or self.traceLevel == 10:
                 centroid_x = np.mean(np.array(removed_corners).T[0])
                 centroid_y = np.mean(np.array(removed_corners).T[1])
 
@@ -640,15 +654,15 @@ class StereoCalibration(object):
                 cbar = plt.colorbar(img, ax=ax)
                 cbar.set_label("Reprojection error")
                 ax.set_xlabel('Width')
-                ax.set_xlim([0,self.width])
-                ax.set_ylim([0,self.height])
+                ax.set_xlim([0,self.width[camera]])
+                ax.set_ylim([0,self.height[camera]])
                 ax.legend()
                 ax.set_ylabel('Y coordinate')
                 plt.grid()
                 plt.show()
 
         if self.traceLevel == 3 or self.traceLevel == 5 or self.traceLevel == 10:
-            center_x, center_y = self.width / 2, self.height / 2
+            center_x, center_y = self.width[camera] / 2, self.height[camera] / 2
             distances = [distance((center_x, center_y), point) for point in np.array(display_corners)]
             max_distance = max(distances)
             circle = plt.Circle((center_x, center_y), max_distance, color='black', fill=True, label = "Calibrated area", alpha = 0.2)
@@ -663,8 +677,8 @@ class StereoCalibration(object):
             cbar = plt.colorbar(img, ax=ax)
             cbar.set_label("Reprojection error")
             ax.set_xlabel('Width')
-            ax.set_xlim([0,self.width])
-            ax.set_ylim([0,self.height])
+            ax.set_xlim([0,self.width[camera]])
+            ax.set_ylim([0,self.height[camera]])
             ax.legend()
             ax.set_ylabel('Height')
             plt.grid()
@@ -698,13 +712,13 @@ class StereoCalibration(object):
             plt.colorbar(label='Reprojection error')
             contours = plt.contour(grid_x, grid_y, grid_z, 7, colors ="black", alpha = 0.7, linewidths = 0.5, linestyles = "dashed")
             plt.clabel(contours, inline=True, fontsize=8)
-            plt.xlim([0,self.width])
-            plt.ylim([0,self.height])
+            plt.xlim([0,self.width[camera]])
+            plt.ylim([0,self.height[camera]])
             plt.grid()
             plt.show()
 
         if self.traceLevel == 11:
-            sorted_points, quadrant_coords = sort_points_into_quadrants(display_points, self.width, self.height, error=all_error)
+            sorted_points, quadrant_coords = sort_points_into_quadrants(display_points, self.width[camera], self.height[camera], error=all_error)
             quadrant_width = self.width // nx
             quadrant_height = self.height // ny
 
@@ -883,7 +897,7 @@ class StereoCalibration(object):
                 ids, charucos = charuco_img
                 allCorners.append(charucos)
                 allIds.append(ids)
-            imsize = (self.height, self.width)
+            imsize = (self.height[name], self.width[name])
 
         coverageImage = np.ones(imsize[::-1], np.uint8) * 255
         coverageImage = cv2.cvtColor(coverageImage, cv2.COLOR_GRAY2BGR)
@@ -1006,8 +1020,10 @@ class StereoCalibration(object):
             cameraMatrixInit = np.array([[f,    0.0,      imsize[0]/2],
                                      [0.0,     f,      imsize[1]/2],
                                      [0.0,   0.0,        1.0]])
+            threshold = 50 * imsize[1]/800.0
         else:
             cameraMatrixInit = self.cameraIntrinsics[name]
+            threshold = 5 * imsize[1]/800.0
        
         if self.traceLevel == 3 or self.traceLevel == 10:
             print(
@@ -1053,7 +1069,6 @@ class StereoCalibration(object):
         translation_array_z = []
         corner_checker = 0
         previous_ids = []
-        threshold = 10
         import time
         try:
             whole = time.time()
@@ -1098,11 +1113,12 @@ class StereoCalibration(object):
                     criteria=(cv2.TERM_CRITERIA_EPS & cv2.TERM_CRITERIA_COUNT, 50000, 1e-9))
                 cameraMatrixInit = camera_matrix
                 distCoeffsInit = distortion_coefficients
+                threshold = 5 * imsize[1]/800.0
                 print(f"Each calibration {time.time()-start}")
                 index += 1
                 if  index > 5 or (previous_ids == removed_ids and len(previous_ids) >= len(removed_ids) and index > 2):
                     print(f"Whole procedure: {time.time() - whole}")
-                    if self.traceLevel == 8:
+                    if self.traceLevel == 9:
                         fig.suptitle(f"Histograms of reprojection error for threshold {threshold}")
                         ax.legend()
                         ax.grid()
@@ -1120,9 +1136,9 @@ class StereoCalibration(object):
                         plt.grid()
                         plt.show()
                         plt.title(f"Distortion after {int(index) + 1} iterations, threshold {threshold}")
-                        """for key, distortion in distortion_array.items():
+                        for key, distortion in distortion_array.items():
                             if distortion[0] != 0:
-                                plt.plot(iterations_array,distortion, label = f"Distortion: {key}")"""
+                                plt.plot(iterations_array,distortion, label = f"Distortion: {key}")
                         plt.ylabel("Absolute change")
                         plt.grid()
                         plt.legend()
@@ -1315,8 +1331,9 @@ class StereoCalibration(object):
                 R=r_in, T=t_in, criteria=stereocalib_criteria , flags=flags)
 
                 r_euler = Rotation.from_matrix(R).as_euler('xyz', degrees=True)
-                scale = ((cameraMatrix_l[0][0]*cameraMatrix_r[0][0] + cameraMatrix_l[1][1]*cameraMatrix_r[1][1])/2)
-                print(f'Epipolar error is {ret*np.sqrt(scale)}')
+                scale = ((cameraMatrix_l[0][0]*cameraMatrix_r[0][0]))
+                print(f'Epipolar error without scale: {ret}')
+                print(f'Epipolar error with scale: {ret*np.sqrt(scale)}')
                 print('Printing Extrinsics res...')
                 print(R)
                 print(T)
@@ -1767,8 +1784,8 @@ class StereoCalibration(object):
                          (0, 255, 0), 1)
                 line_row += 30
 
-            #cv2.imshow('Stereo Pair', img_concat)
-            #k = cv2.waitKey(0)
+            cv2.imshow('Stereo Pair', img_concat)
+            k = cv2.waitKey(0)
             
             if res2_l[1] is not None and res2_r[2] is not None and len(res2_l[1]) > 3 and len(res2_r[1]) > 3:
 

--- a/calibration_utils.py
+++ b/calibration_utils.py
@@ -95,7 +95,7 @@ class StereoCalibration(object):
         """Function to calculate calibration for stereo camera."""
         start_time = time.time()
         # init object data
-        if self.traceLevel == 1 or self.traceLevel == 10:
+        if self.traceLevel == 2 or self.traceLevel == 10:
             print(f'squareX is {squaresX}')
         self.enable_rectification_disp = enable_disp_rectify
         self.cameraModel = camera_model
@@ -140,7 +140,7 @@ class StereoCalibration(object):
             cam_info['reprojection_error'] = ret
             print("Reprojection error of {0}: {1}".format(
                 cam_info['name'], ret))
-            if self.traceLevel == 1 or self.traceLevel == 10:
+            if self.traceLevel == 3 or self.traceLevel == 10:
                 print("Estimated intrinsics of {0}: \n {1}".format(
                 cam_info['name'], intrinsics))
             
@@ -272,7 +272,7 @@ class StereoCalibration(object):
         count = 0
         skip_vis = False
         for im in images:
-            if self.traceLevel == 2 or self.traceLevel == 10:
+            if self.traceLevel == 3 or self.traceLevel == 10:
                 print("=> Processing image {0}".format(im))
             img_pth = Path(im)
             frame = cv2.imread(im)
@@ -306,7 +306,7 @@ class StereoCalibration(object):
                 gray, self.aruco_dictionary)
             marker_corners, ids, refusd, recoverd = cv2.aruco.refineDetectedMarkers(gray, self.board,
                                                                                     marker_corners, ids, rejectedCorners=rejectedImgPoints)
-            if self.traceLevel == 3 or self.traceLevel == 10:
+            if self.traceLevel == 2 or self.traceLevel == 4 or self.traceLevel == 10:
                 print('{0} number of Markers corners detected in the image {1}'.format(
                     len(marker_corners), img_pth.name))
             if len(marker_corners) > 0:
@@ -329,7 +329,7 @@ class StereoCalibration(object):
             else:
                 print(im + " Not found")
                 raise RuntimeError("Failed to detect markers in the image")
-            if self.traceLevel == 3 or self.traceLevel == 10:
+            if self.traceLevel == 2 or self.traceLevel == 4 or self.traceLevel == 10:
                 rgb_img = cv2.cvtColor(gray, cv2.COLOR_GRAY2BGR)
                 cv2.aruco.drawDetectedMarkers(rgb_img, marker_corners, ids, (0, 0, 255))
                 cv2.aruco.drawDetectedCornersCharuco(rgb_img, charuco_corners, charuco_ids, (0, 255, 0))
@@ -362,7 +362,7 @@ class StereoCalibration(object):
             ret, camera_matrix, distortion_coefficients, rotation_vectors, translation_vectors = self.calibrate_camera_charuco(
                 allCorners, allIds, imsize, hfov)
             # (Height, width)
-            if self.traceLevel == 3 or self.traceLevel == 10:
+            if self.traceLevel == 4 or self.traceLevel == 5 or self.traceLevel == 10:
                 self.undistort_visualization(
                     image_files, camera_matrix, distortion_coefficients, imsize)
 
@@ -371,7 +371,7 @@ class StereoCalibration(object):
             print('Fisheye--------------------------------------------------')
             ret, camera_matrix, distortion_coefficients, rotation_vectors, translation_vectors = self.calibrate_fisheye(
                 allCorners, allIds, imsize)
-            if self.traceLevel == 3 or self.traceLevel == 10:
+            if self.traceLevel == 4 or self.traceLevel == 5 or self.traceLevel == 10:
                 self.undistort_visualization(
                     image_files, camera_matrix, distortion_coefficients, imsize)
             print('Fisheye rotation vector', rotation_vectors[0])
@@ -418,7 +418,7 @@ class StereoCalibration(object):
             # if scaled_height <  smaller_res[0]:
             if diff < 0:
                 scaled_res = (int(scaled_height), scaled_res[1])
-        if self.traceLevel == 4 or self.traceLevel == 10:
+        if self.traceLevel == 3 or self.traceLevel == 10:
             print(
                 f'Is scale Req: {scale_req}\n scale value: {scale} \n scalable Res: {scalable_res} \n scale Res: {scaled_res}')
             print("Original res Left :{}".format(frame_left_shape))
@@ -436,7 +436,7 @@ class StereoCalibration(object):
         # print("~~~~~~~~~~~ POSE ESTIMATION RIGHT CAMERA ~~~~~~~~~~~~~")
         allCorners_r, allIds_r, _, _, imsize_r, _ = self.analyze_charuco(
             images_right, scale_req, scaled_res)
-        if self.traceLevel == 4 or self.traceLevel == 10:
+        if self.traceLevel == 3 or self.traceLevel == 10:
             print(f'Image size of right side (w, h): {imsize_r}')
             print(f'Image size of left side (w, h): {imsize_l}')
 
@@ -457,7 +457,7 @@ class StereoCalibration(object):
                                     * scale - destShape[0]) / 2
         scaled_intrinsics[0][2] -= (originalShape[1]     # c_x width of the image
                                     * scale - destShape[1]) / 2
-        if self.traceLevel == 2 or self.traceLevel == 10:
+        if self.traceLevel == 3 or self.traceLevel == 10:
             print('original_intrinsics')
             print(intrinsics)
             print('scaled_intrinsics')
@@ -483,7 +483,7 @@ class StereoCalibration(object):
             undistorted_img = cv2.remap(
                 img, map1, map2, interpolation=cv2.INTER_LINEAR, borderMode=cv2.BORDER_CONSTANT)
             cv2.imshow("undistorted", undistorted_img)
-            if self.traceLevel == 4 or self.traceLevel == 10:
+            if self.traceLevel == 3 or self.traceLevel == 10:
                 print(f'image path - {im}')
                 print(f'Image Undistorted Size {undistorted_img.shape}')
             k = cv2.waitKey(0)
@@ -518,7 +518,7 @@ class StereoCalibration(object):
             cameraMatrixInit = np.array([[3819.8801,    0.0,     1912.8375],
                                          [0.0,     3819.8801, 1135.3433],
                                          [0.0,        0.0,        1.]]) """
-        if self.traceLevel == 1 or self.traceLevel == 10:
+        if self.traceLevel == 3 or self.traceLevel == 10:
             print(
                 f'Camera Matrix initialization with HFOV of {hfov} is.............')
             print(cameraMatrixInit)
@@ -540,7 +540,7 @@ class StereoCalibration(object):
             distCoeffs=distCoeffsInit,
             flags=flags,
             criteria=(cv2.TERM_CRITERIA_EPS & cv2.TERM_CRITERIA_COUNT, 50000, 1e-9))
-        if self.traceLevel == 2 or self.traceLevel == 10:
+        if self.traceLevel == 3 or self.traceLevel == 10:
             print('Per View Errors...')
             print(perViewErrors)
         return ret, camera_matrix, distortion_coefficients, rotation_vectors, translation_vectors
@@ -577,15 +577,11 @@ class StereoCalibration(object):
         obj_pts = []
         one_pts = self.board.chessboardCorners
         
-        if self.traceLevel == 5 or self.traceLevel == 10:
+        if self.traceLevel == 2 or self.traceLevel == 4 or self.traceLevel == 10:
             print('Length of allIds_l')
             print(len(allIds_l))
             print('Length of allIds_r')
             print(len(allIds_r))
-            print('allIds_l')
-            print(allIds_l)
-            print('allIds_r')
-            print(allIds_r)
 
         for i in range(len(allIds_l)):
             left_sub_corners = []
@@ -621,7 +617,7 @@ class StereoCalibration(object):
             # flags |= cv2.CALIB_USE_INTRINSIC_GUESS
             flags |= cv2.CALIB_RATIONAL_MODEL
             # print(flags)
-            if self.traceLevel == 1 or self.traceLevel == 10:
+            if self.traceLevel == 3 or self.traceLevel == 10:
                 print('Printing Extrinsics guesses...')
                 print(r_in)
                 print(t_in)
@@ -632,7 +628,7 @@ class StereoCalibration(object):
 
             r_euler = Rotation.from_matrix(R).as_euler('xyz', degrees=True)
             print(f'Reprojection error is {ret}')
-            if self.traceLevel == 5 or self.traceLevel == 10:
+            if self.traceLevel == 3 or self.traceLevel == 10:
                 print('Printing Extrinsics res...')
                 print(R)
                 print(T)
@@ -986,7 +982,7 @@ class StereoCalibration(object):
             diff = scaled_height - scaled_res[0]
             if diff < 0:
                 scaled_res = (int(scaled_height), scaled_res[1])
-        if self.traceLevel == 4 or self.traceLevel == 10:
+        if self.traceLevel == 3 or self.traceLevel == 10:
             print(
                 f'Is scale Req: {scale_req}\n scale value: {scale} \n scalable Res: {scalable_res} \n scale Res: {scaled_res}')
             print("Original res Left :{}".format(frame_left_shape))
@@ -1010,7 +1006,7 @@ class StereoCalibration(object):
         print('Original intrinsics ....')
         print(f"L {M_lp}")
         print(f"R: {M_rp}")
-        if self.traceLevel == 4 or self.traceLevel == 10:
+        if self.traceLevel == 3 or self.traceLevel == 10:
             print(f'Width and height is {scaled_res[::-1]}')
         # kScaledL, _ = cv2.getOptimalNewCameraMatrix(M_r, d_r, scaled_res[::-1], 0)
         # kScaledL, _ = cv2.getOptimalNewCameraMatrix(M_r, d_l, scaled_res[::-1], 0)
@@ -1119,7 +1115,7 @@ class StereoCalibration(object):
 
             image_data_pairs.append((img_l, img_r))
             
-            if self.traceLevel == 4 or self.traceLevel == 10:
+            if self.traceLevel == 4 or self.traceLevel == 5 or self.traceLevel == 10:
                 cv2.imshow("undistorted-Left", img_l)
                 cv2.imshow("undistorted-right", img_r)
                 # print(f'image path - {im}')
@@ -1127,7 +1123,7 @@ class StereoCalibration(object):
                 k = cv2.waitKey(0)
                 if k == 27:  # Esc key to stop
                     break
-        if self.traceLevel == 4 or self.traceLevel == 10:
+        if self.traceLevel == 4 or self.traceLevel == 5 or self.traceLevel == 10:
           cv2.destroyWindow("undistorted-Left")
           cv2.destroyWindow("undistorted-right")  
         # compute metrics
@@ -1148,7 +1144,7 @@ class StereoCalibration(object):
             marker_corners_r, ids_r, _, _ = cv2.aruco.refineDetectedMarkers(image_data_pair[1], self.board,
                                                                             marker_corners_r, ids_r,
                                                                             rejectedCorners=rejectedImgPoints)
-            if self.traceLevel == 4 or self.traceLevel == 10:
+            if self.traceLevel == 2 or self.traceLevel == 4 or self.traceLevel == 10:
                 print(f'Marekrs length for pair {i} is: L {len(marker_corners_l)} | R {len(marker_corners_r)} ')
             #print(f'Marekrs length l is {len(marker_corners_l)}')
             res2_l = cv2.aruco.interpolateCornersCharuco(
@@ -1212,7 +1208,7 @@ class StereoCalibration(object):
                     epi_error_sum += curr_epipolar_error
                 localError = epi_error_sum / len(corners_l)
                 image_epipolar_color.append(corner_epipolar_color)
-                if self.traceLevel == 4 or self.traceLevel == 10:
+                if self.traceLevel == 2 or self.traceLevel == 3 or self.traceLevel == 4 or self.traceLevel == 10:
                     print("Epipolar Error per image on host in " + img_pth_right.name + " : " +
                         str(localError))
             else:

--- a/calibration_utils.py
+++ b/calibration_utils.py
@@ -497,27 +497,12 @@ class StereoCalibration(object):
         Calibrates the camera using the dected corners.
         """
         f = imsize[0] / (2 * np.tan(np.deg2rad(hfov/2)))
-        # TODO(sachin): Change the initialization to be initialized using the guess from fov
+
         print("INTRINSIC CALIBRATION")
         cameraMatrixInit = np.array([[f,    0.0,      imsize[0]/2],
                                      [0.0,     f,      imsize[1]/2],
                                      [0.0,   0.0,        1.0]])
-
-        # cameraMatrixInit = np.array([[857.1668,    0.0,      643.9126],
-        #                                  [0.0,     856.0823,  387.56018],
-        #                                  [0.0,        0.0,        1.0]])
-        """ if imsize[1] < 700:
-            cameraMatrixInit = np.array([[400.0,    0.0,      imsize[0]/2],
-                                         [0.0,     400.0,  imsize[1]/2],
-                                         [0.0,        0.0,        1.0]])
-        elif imsize[1] < 1100:
-            cameraMatrixInit = np.array([[857.1668,    0.0,      643.9126],
-                                         [0.0,     856.0823,  387.56018],
-                                         [0.0,        0.0,        1.0]])
-        else:
-            cameraMatrixInit = np.array([[3819.8801,    0.0,     1912.8375],
-                                         [0.0,     3819.8801, 1135.3433],
-                                         [0.0,        0.0,        1.]]) """
+       
         if self.traceLevel == 3 or self.traceLevel == 10:
             print(
                 f'Camera Matrix initialization with HFOV of {hfov} is.............')
@@ -596,12 +581,6 @@ class StereoCalibration(object):
         flags |= cv2.fisheye.CALIB_RECOMPUTE_EXTRINSIC
         flags |= cv2.fisheye.CALIB_FIX_SKEW
         
-        # distCoeffsInit = np.array([
-        # -0.028964687138795853,
-        # 0.012780099175870419,
-        # -0.010693552903831005,
-        # 0.0013224288122728467
-        # ])
 
         term_criteria = (cv2.TERM_CRITERIA_COUNT +
                          cv2.TERM_CRITERIA_EPS, 30, 1e-9)
@@ -1094,10 +1073,10 @@ class StereoCalibration(object):
                          (0, 255, 0), 1)
                 line_row += 30
 
-            cv2.imshow('Stereo Pair', img_concat)
-            k = cv2.waitKey(0)
-            if k == 27:  # Esc key to stop
-                break
+            # cv2.imshow('Stereo Pair', img_concat)
+            # k = cv2.waitKey(0)
+            # if k == 27:  # Esc key to stop
+            #     break
             
             if res2_l[1] is not None and res2_r[2] is not None and len(res2_l[1]) > 3 and len(res2_r[1]) > 3:
 

--- a/calibration_utils.py
+++ b/calibration_utils.py
@@ -533,22 +533,29 @@ class StereoCalibration(object):
             obj_points = []
             for i in range(len(filtered_ids)):
                 obj_points.append(self.charuco_ids_to_objpoints(filtered_ids[i]))
-
+        flags = cv2.CALIB_USE_INTRINSIC_GUESS
         if self.model == None:
-            flags = (cv2.CALIB_USE_INTRINSIC_GUESS + 
-                 cv2.CALIB_RATIONAL_MODEL)
+            print("Use DEFAULT model")
+            flags += cv2.CALIB_RATIONAL_MODEL
+
         elif isinstance(self.model, str):
             if self.model == "NORMAL":
-                flags = (cv2.CALIB_USE_INTRINSIC_GUESS + 
-                    cv2.CALIB_RATIONAL_MODEL)
+                print("Using NORMAL model")
+                flags += cv2.CALIB_RATIONAL_MODEL
+
             elif self.model == "TILTED":
-                flags = (cv2.CALIB_USE_INTRINSIC_GUESS + 
-                    cv2.CALIB_RATIONAL_MODEL + cv2.CALIB_TILTED_MODEL)
+                print("Using TILTED model")
+                flags += cv2.CALIB_RATIONAL_MODEL
+                flags += cv2.CALIB_TILTED_MODEL
 
             elif self.model == "PRISM":
-                flags = (cv2.CALIB_USE_INTRINSIC_GUESS + 
-                    cv2.CALIB_RATIONAL_MODEL + cv2.CALIB_TILTED_MODEL)
-        elif "cv2" in str(type(self.model)):
+                print("Using PRISM model")
+                flags += cv2.CALIB_RATIONAL_MODEL
+                flags += cv2.CALIB_TILTED_MODEL
+                flags += cv2.CALIB_THIN_PRISM_MODEL
+
+        elif isinstance(self.model, int):
+            print("Using CUSTOM flags")
             flags = self.model
 
     #     flags = (cv2.CALIB_RATIONAL_MODEL)
@@ -693,22 +700,22 @@ class StereoCalibration(object):
             flags = 0
             # flags |= cv2.CALIB_USE_EXTRINSIC_GUESS
             # print(flags)
-
+            flags = cv2.CALIB_FIX_INTRINSIC
             if self.model == None:
-                flags = (cv2.CALIB_FIX_INTRINSIC + 
-                    cv2.CALIB_RATIONAL_MODEL)
+                flags += cv2.CALIB_RATIONAL_MODEL
             elif isinstance(self.model, str):
                 if self.model == "NORMAL":
-                    flags = (cv2.CALIB_FIX_INTRINSIC + 
-                        cv2.CALIB_RATIONAL_MODEL)
+                    flags += cv2.CALIB_RATIONAL_MODEL
                 if self.model == "TILTED":
-                    flags = (cv2.CALIB_FIX_INTRINSIC + 
-                        cv2.CALIB_RATIONAL_MODEL + cv2.CALIB_TILTED_MODEL)
+                    flags += cv2.CALIB_RATIONAL_MODEL 
+                    flags += cv2.CALIB_TILTED_MODEL
 
                 elif self.model == "PRISM":
-                    flags = (cv2.CALIB_FIX_INTRINSIC + 
-                        cv2.CALIB_RATIONAL_MODEL + cv2.CALIB_TILTED_MODEL)
-            elif "cv2" in str(type(self.model)):
+                    flags += cv2.CALIB_RATIONAL_MODEL 
+                    flags += cv2.CALIB_TILTED_MODEL
+                    flags += cv2.CALIB_THIN_PRISM_MODEL
+
+            elif isinstance(self.model, int):
                 flags = self.model
             # print(flags)
             if self.traceLevel == 3 or self.traceLevel == 10:


### PR DESCRIPTION
Improvements for Fisheye calibration. Tested on RX.

The intrinsic calibration is sensitive to initialization. Now if calibration fails due to OpenCV - ill conditioned matrix error, the calibration is attempted again with a smaller portion of FOV covered. As the FOV gets narrower, the model behaves better and the calibration has a chance to succeed. The initial K matrix found with smaller FOV is then used to initialize the calibration on full FOV and if it succeeds it is returned. Otherwise the calibration with largest FOV is returned. The FOV is not reduced more than by a factor of 0.7.