### PR TITLE
Generalize image extension in test_epipolar_charuco().

### DIFF
--- a/calibration_utils.py
+++ b/calibration_utils.py
@@ -958,8 +958,8 @@ class StereoCalibration(object):
 
 
     def test_epipolar_charuco(self, left_img_pth, right_img_pth, M_l, d_l, M_r, d_r, t, r_l, r_r, p_l, p_r):
-        images_left = glob.glob(left_img_pth + '/*.png')
-        images_right = glob.glob(right_img_pth + '/*.png')
+        images_left = glob.glob(left_img_pth + '/*')
+        images_right = glob.glob(right_img_pth + '/*')
         images_left.sort()
         images_right.sort()
         assert len(images_left) != 0, "ERROR: Images not read correctly"


### PR DESCRIPTION
This generalizes what images can be used in test_epipolar_utils(), similar to other points in the code. This is useful if users are trying to calibrate offline using a set of jpegs generated with the on-board encoders. Thanks for considering!