### PR TITLE
Fix: Prevent ValueError in hstack by forcing height match

### DIFF
--- a/calibration_utils.py
+++ b/calibration_utils.py
@@ -355,10 +355,14 @@ class StereoCalibration(object):
                 width_offset = (resizeWidth - width)//2
                 subImage = np.pad(coverageImage, ((height_offset, height_offset), (width_offset, width_offset), (0, 0)), 'constant', constant_values=0)
                 cv2.putText(subImage, print_text, (50, 50+height_offset), cv2.FONT_HERSHEY_SIMPLEX, 2*coverageImage.shape[0]/1750, (0, 0, 0), 2)
-                if combinedCoverageImage is None:
-                    combinedCoverageImage = subImage
-                else:
+                if combinedCoverageImage is not None:
+                    if subImage.shape[0] != combinedCoverageImage.shape[0]:
+                        print(f"Warning: dimension mismatch {subImage.shape[0]} vs {combinedCoverageImage.shape[0]}, resizing subImage")
+                        new_width = int(subImage.shape[1] * (combinedCoverageImage.shape[0] / subImage.shape[0]))
+                        subImage = cv2.resize(subImage, (new_width, combinedCoverageImage.shape[0]))
                     combinedCoverageImage = np.hstack((combinedCoverageImage, subImage))
+                else:
+                    combinedCoverageImage = subImage
                 coverage_file_path = filepath + '/' + coverage_name + '_coverage.png'
                 
                 cv2.imwrite(coverage_file_path, subImage)


### PR DESCRIPTION
## Purpose
Prevents a ValueError crash during calibration post-processing. Rounding errors in sensor scaling occasionally create a 1-pixel height mismatch (e.g. 479px vs 480px in my case), causing `np.hstack` to fail generating the coverage report.

## Specification
Added a dimensional guard in `calibration_utils.py`. Before horizontal stacking, the script now verifies if the `subImage` height matches the `combinedCoverageImage` and performs a `cv2.resize` if a mismatch is detected.

## Dependencies & Potential Impact
None / not applicable

## Deployment Plan
None / not applicable

## Testing & Validation
Validated with OAK-D Lite, running the calibration process. Confirmed the fix bypasses the crash, generates the combined image correctly, and allows the calibration finish successfully.